### PR TITLE
Fix documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 <li> smtplib</li>
 <li>requests</li>
 <li>json</li>
-<li>defflib</li>
+<li>difflib</li>
 <li>geocoder</li>
 <li>pyjokes</li>
 <li>psutil</li>


### PR DESCRIPTION
## Summary
- correct the typo "defflib" -> "difflib" in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eaae4d3f483339a7bbfc0d783e329