### PR TITLE
Add configurable screenshot path

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Set the following variables in your shell or `.env` file before running J.A.R.V.
 - `CHROME_PATH` – optional path to the Chrome executable
 - `TESSERACT_CMD` – optional path to the Tesseract OCR executable
 - `MUSIC_FILE` – optional path of the mp3 file used when the "play music" command is triggered
+- `SCREENSHOT_PATH` – optional file destination for screenshots (defaults to `screenshot.png`)
 
 
 ### What it does...

--- a/helpers.py
+++ b/helpers.py
@@ -1,3 +1,4 @@
+import os
 import pyttsx3
 import pyautogui
 import psutil
@@ -21,9 +22,28 @@ def speak(audio) -> None:
     engine.runAndWait()
 
 
-def screenshot() -> None:
+def screenshot(path: str | None = None) -> str:
+    """Save a screenshot to ``path``.
+
+    Parameters
+    ----------
+    path:
+        Destination file path. If ``None`` (default), the ``SCREENSHOT_PATH``
+        environment variable is consulted. When neither is provided the image
+        is saved as ``screenshot.png`` in the current working directory.
+
+    Returns
+    -------
+    str
+        The absolute path of the saved screenshot.
+    """
+
+    if path is None:
+        path = os.getenv("SCREENSHOT_PATH", "screenshot.png")
+
     img = pyautogui.screenshot()
-    img.save("path of folder you want to save/screenshot.png")
+    img.save(path)
+    return os.path.abspath(path)
 
 
 def cpu() -> None:


### PR DESCRIPTION
## Summary
- allow `helpers.screenshot()` to save to a path from `SCREENSHOT_PATH` or a provided argument
- document the new environment variable

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eaae623d08333b1bbb5ae124f548b