### PR TITLE
Add Docker ignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Ignore image files
+*.jpg
+*.jpeg
+*.png
+*.gif
+*.bmp
+
+# Ignore wheel distributions
+*.whl
+
+# Ignore test files and directories
+tests/
+images/


### PR DESCRIPTION
## Summary
- ignore artifacts that don't need to be sent to Docker builds

## Testing
- `pytest -q`
- `docker build -t jarvis .` *(fails: `docker` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686eaae7ed0c83339839c03ebae6d4d0