### PR TITLE
Refactor execute_query dispatch

### DIFF
--- a/jarvis.py
+++ b/jarvis.py
@@ -64,169 +64,138 @@ class Jarvis:
         server.sendmail(user, to, content)
         server.close()
 
+    def _handle_wikipedia(self, query):
+        speak("Searching Wikipedia....")
+        query = query.replace("wikipedia", "")
+        results = wikipedia.summary(query, sentences=2)
+        speak("According to Wikipedia")
+        print(results)
+        speak(results)
+
+    def _change_voice(self, query):
+        if "female" in query:
+            engine.setProperty("voice", voices[1].id)
+        else:
+            engine.setProperty("voice", voices[0].id)
+        speak("Hello Sir, I have switched my voice. How is it?")
+
+    def _play_music(self):
+        music_file = os.getenv("MUSIC_FILE", "D:\\RoiNa.mp3")
+        os.startfile(music_file)
+
+    def _search(self):
+        speak("What do you want to search for?")
+        search = takeCommand()
+        url = "https://google.com/search?q=" + search
+        webbrowser.get("chrome").open_new_tab(url)
+        speak("Here is What I found for" + search)
+
+    def _location(self):
+        speak("What is the location?")
+        location = takeCommand()
+        url = "https://google.nl/maps/place/" + location + "/&amp;"
+        webbrowser.get("chrome").open_new_tab(url)
+        speak("Here is the location " + location)
+
+    def _your_master(self):
+        if platform == "win32" or "darwin":
+            speak("Gaurav is my master. He created me couple of days ago")
+        elif platform == "linux" or platform == "linux2":
+            name = getpass.getuser()
+            speak(name, "is my master. He is running me right now")
+
+    def _open_code(self):
+        if platform == "win32":
+            os.startfile(
+                "C:\\Users\\gs935\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe"
+            )
+        elif platform == "linux" or platform == "linux2" or "darwin":
+            os.system("code .")
+
+    def _shutdown(self):
+        if platform == "win32":
+            os.system("shutdown /p /f")
+        elif platform == "linux" or platform == "linux2" or "darwin":
+            os.system("poweroff")
+
+    def _remember_that(self):
+        speak("what should i remember sir")
+        rememberMessage = takeCommand()
+        speak("you said me to remember" + rememberMessage)
+        remember = open("data.txt", "w")
+        remember.write(rememberMessage)
+        remember.close()
+
+    def _do_you_remember(self):
+        remember = open("data.txt", "r")
+        speak("you said me to remember that" + remember.read())
+
+    def _dictionary(self):
+        speak("What you want to search in your intelligent dictionary?")
+        translate(takeCommand())
+
+    def _news(self):
+        speak("Ofcourse sir..")
+        speak_news()
+        speak("Do you want to read the full news...")
+        test = takeCommand()
+        if "yes" in test:
+            speak("Ok Sir, Opening browser...")
+            webbrowser.open(getNewsUrl())
+            speak("You can now read the full news from this website.")
+        else:
+            speak("No Problem Sir")
+
+    def _email_to_gaurav(self):
+        try:
+            speak("What should I say?")
+            content = takeCommand()
+            to = "email"
+            self.sendEmail(to, content)
+            speak("Email has been sent!")
+
+        except Exception:
+            speak("Sorry sir, Not able to send email at the moment")
+
     def execute_query(self, query):
-        # TODO: make this more concise
-        if "wikipedia" in query:
-            speak("Searching Wikipedia....")
-            query = query.replace("wikipedia", "")
-            results = wikipedia.summary(query, sentences=2)
-            speak("According to Wikipedia")
-            print(results)
-            speak(results)
-        elif "youtube downloader" in query:
-            exec(open("youtube_downloader.py").read())
+        actions = {
+            "wikipedia": lambda: self._handle_wikipedia(query),
+            "youtube downloader": lambda: exec(open("youtube_downloader.py").read()),
+            "voice": lambda: self._change_voice(query),
+            "jarvis are you there": lambda: speak("Yes Sir, at your service"),
+            "jarvis who made you": lambda: speak("Yes Sir, my master build me in AI"),
+            "open youtube": lambda: webbrowser.get("chrome").open_new_tab("https://youtube.com"),
+            "open amazon": lambda: webbrowser.get("chrome").open_new_tab("https://amazon.com"),
+            "cpu": cpu,
+            "joke": joke,
+            "screenshot": lambda: (speak("taking screenshot"), screenshot()),
+            "open google": lambda: webbrowser.get("chrome").open_new_tab("https://google.com"),
+            "open stackoverflow": lambda: webbrowser.get("chrome").open_new_tab("https://stackoverflow.com"),
+            "play music": self._play_music,
+            "search youtube": lambda: (speak("What you want to search on Youtube?"), youtube(takeCommand())),
+            "the time": lambda: speak(f"Sir, the time is {datetime.datetime.now().strftime('%H:%M:%S')}"),
+            "search": self._search,
+            "location": self._location,
+            "your master": self._your_master,
+            "your name": lambda: speak("My name is JARVIS"),
+            "who made you": lambda: speak("I was created by my AI master in 2021"),
+            "stands for": lambda: speak("J.A.R.V.I.S stands for JUST A RATHER VERY INTELLIGENT SYSTEM"),
+            "open code": self._open_code,
+            "shutdown": self._shutdown,
+            "your friend": lambda: speak("My friends are Google assisstant alexa and siri"),
+            "github": lambda: webbrowser.get("chrome").open_new_tab("https://github.com/gauravsingh9356"),
+            "remember that": self._remember_that,
+            "do you remember anything": self._do_you_remember,
+            "sleep": lambda: sys.exit(),
+            "dictionary": self._dictionary,
+            "news": self._news,
+            "email to gaurav": self._email_to_gaurav,
+        }
 
-        elif "voice" in query:
-            if "female" in query:
-                engine.setProperty("voice", voices[1].id)
-            else:
-                engine.setProperty("voice", voices[0].id)
-            speak("Hello Sir, I have switched my voice. How is it?")
-
-        if "jarvis are you there" in query:
-            speak("Yes Sir, at your service")
-        if "jarvis who made you" in query:
-            speak("Yes Sir, my master build me in AI")
-
-        elif "open youtube" in query:
-
-            webbrowser.get("chrome").open_new_tab("https://youtube.com")
-
-        elif "open amazon" in query:
-            webbrowser.get("chrome").open_new_tab("https://amazon.com")
-
-        elif "cpu" in query:
-            cpu()
-
-        elif "joke" in query:
-            joke()
-
-        elif "screenshot" in query:
-            speak("taking screenshot")
-            screenshot()
-
-        elif "open google" in query:
-            webbrowser.get("chrome").open_new_tab("https://google.com")
-
-        elif "open stackoverflow" in query:
-            webbrowser.get("chrome").open_new_tab("https://stackoverflow.com")
-
-        elif "play music" in query:
-            music_file = os.getenv("MUSIC_FILE", "D:\\RoiNa.mp3")
-            os.startfile(music_file)
-
-        elif "search youtube" in query:
-            speak("What you want to search on Youtube?")
-            youtube(takeCommand())
-        elif "the time" in query:
-            strTime = datetime.datetime.now().strftime("%H:%M:%S")
-            speak(f"Sir, the time is {strTime}")
-
-        elif "search" in query:
-            speak("What do you want to search for?")
-            search = takeCommand()
-            url = "https://google.com/search?q=" + search
-            webbrowser.get("chrome").open_new_tab(url)
-            speak("Here is What I found for" + search)
-
-        elif "location" in query:
-            speak("What is the location?")
-            location = takeCommand()
-            url = "https://google.nl/maps/place/" + location + "/&amp;"
-            webbrowser.get("chrome").open_new_tab(url)
-            speak("Here is the location " + location)
-
-        elif "your master" in query:
-            if platform == "win32" or "darwin":
-                speak("Gaurav is my master. He created me couple of days ago")
-            elif platform == "linux" or platform == "linux2":
-                name = getpass.getuser()
-                speak(name, "is my master. He is running me right now")
-
-        elif "your name" in query:
-            speak("My name is JARVIS")
-        elif "who made you" in query:
-            speak("I was created by my AI master in 2021")
-
-        elif "stands for" in query:
-            speak("J.A.R.V.I.S stands for JUST A RATHER VERY INTELLIGENT SYSTEM")
-        elif "open code" in query:
-            if platform == "win32":
-                os.startfile(
-                    "C:\\Users\\gs935\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe"
-                )
-            elif platform == "linux" or platform == "linux2" or "darwin":
-                os.system("code .")
-
-        elif "shutdown" in query:
-            if platform == "win32":
-                os.system("shutdown /p /f")
-            elif platform == "linux" or platform == "linux2" or "darwin":
-                os.system("poweroff")
-
-        elif "cpu" in query:
-            cpu()
-        elif "your friend" in query:
-            speak("My friends are Google assisstant alexa and siri")
-
-        elif "joke" in query:
-            joke()
-
-        elif "screenshot" in query:
-            speak("taking screenshot")
-            screenshot()
-
-        elif "github" in query:
-            webbrowser.get("chrome").open_new_tab("https://github.com/gauravsingh9356")
-
-        elif "remember that" in query:
-            speak("what should i remember sir")
-            rememberMessage = takeCommand()
-            speak("you said me to remember" + rememberMessage)
-            remember = open("data.txt", "w")
-            remember.write(rememberMessage)
-            remember.close()
-
-        elif "do you remember anything" in query:
-            remember = open("data.txt", "r")
-            speak("you said me to remember that" + remember.read())
-
-        elif "sleep" in query:
-            sys.exit()
-
-        elif "dictionary" in query:
-            speak("What you want to search in your intelligent dictionary?")
-            translate(takeCommand())
-
-        elif "news" in query:
-            speak("Ofcourse sir..")
-            speak_news()
-            speak("Do you want to read the full news...")
-            test = takeCommand()
-            if "yes" in test:
-                speak("Ok Sir, Opening browser...")
-                webbrowser.open(getNewsUrl())
-                speak("You can now read the full news from this website.")
-            else:
-                speak("No Problem Sir")
-
-        elif "voice" in query:
-            if "female" in query:
-                engine.setProperty("voice", voices[0].id)
-            else:
-                engine.setProperty("voice", voices[1].id)
-            speak("Hello Sir, I have switched my voice. How is it?")
-
-        elif "email to gaurav" in query:
-            try:
-                speak("What should I say?")
-                content = takeCommand()
-                to = "email"
-                self.sendEmail(to, content)
-                speak("Email has been sent!")
-
-            except Exception:
-                speak("Sorry sir, Not able to send email at the moment")
+        for key, action in actions.items():
+            if key in query:
+                action()
+                break
 
 
 def wakeUpJARVIS():

--- a/tests/test_jarvis.py
+++ b/tests/test_jarvis.py
@@ -1,0 +1,96 @@
+import importlib
+import os
+import sys
+import types
+import pytest
+
+# Fixture to provide the Jarvis module with dummy dependencies
+@pytest.fixture
+def jarvis(monkeypatch):
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+
+    outputs = []
+
+    dummy_engine = types.SimpleNamespace(
+        getProperty=lambda name: [types.SimpleNamespace(id="id0"), types.SimpleNamespace(id="id1")],
+        setProperty=lambda name, value: None,
+        say=lambda text: None,
+        runAndWait=lambda: None,
+    )
+    dummy_pyttsx3 = types.SimpleNamespace(init=lambda: dummy_engine)
+
+    dummy_wikipedia = types.SimpleNamespace(summary=lambda q, sentences=2: f"summary:{q}")
+
+    sr = types.ModuleType("speech_recognition")
+    sr.Recognizer = lambda: None
+    sr.Microphone = object
+
+    dummy_webbrowser = types.SimpleNamespace(
+        register=lambda *a, **k: None,
+        get=lambda *a, **k: types.SimpleNamespace(open_new_tab=lambda url: outputs.append(url)),
+        open=lambda url: outputs.append(url),
+        BackgroundBrowser=lambda path: None,
+    )
+
+    dummy_smtplib = types.SimpleNamespace(
+        SMTP=lambda *a, **k: types.SimpleNamespace(
+            ehlo=lambda: None,
+            starttls=lambda: None,
+            login=lambda *a, **k: None,
+            sendmail=lambda *a, **k: None,
+            close=lambda: None,
+        )
+    )
+
+    dummy_news = types.SimpleNamespace(speak_news=lambda: outputs.append("news"), getNewsUrl=lambda: "http://news")
+    dummy_OCR = types.SimpleNamespace(OCR=lambda: None)
+    dummy_helpers = types.SimpleNamespace(
+        speak=lambda text: outputs.append(text),
+        weather=lambda: outputs.append("weather"),
+        takeCommand=lambda: "dummy",
+        cpu=lambda: outputs.append("cpu"),
+        joke=lambda: outputs.append("joke"),
+        screenshot=lambda: outputs.append("screenshot"),
+    )
+    dummy_translate_mod = types.SimpleNamespace(translate=lambda word: outputs.append(f"translate:{word}"))
+    dummy_youtube = types.SimpleNamespace(youtube=lambda q: outputs.append(f"youtube:{q}"))
+    dummy_getpass = types.SimpleNamespace(getuser=lambda: "tester")
+    dummy_cv2 = types.ModuleType("cv2")
+
+    monkeypatch.setitem(sys.modules, "pyttsx3", dummy_pyttsx3)
+    monkeypatch.setitem(sys.modules, "wikipedia", dummy_wikipedia)
+    monkeypatch.setitem(sys.modules, "speech_recognition", sr)
+    monkeypatch.setitem(sys.modules, "webbrowser", dummy_webbrowser)
+    monkeypatch.setitem(sys.modules, "smtplib", dummy_smtplib)
+    monkeypatch.setitem(sys.modules, "news", dummy_news)
+    monkeypatch.setitem(sys.modules, "OCR", dummy_OCR)
+    monkeypatch.setitem(sys.modules, "helpers", dummy_helpers)
+    monkeypatch.setitem(sys.modules, "diction", dummy_translate_mod)
+    monkeypatch.setitem(sys.modules, "youtube", dummy_youtube)
+    monkeypatch.setitem(sys.modules, "getpass", dummy_getpass)
+    monkeypatch.setitem(sys.modules, "cv2", dummy_cv2)
+
+    jarvis_module = importlib.import_module("jarvis")
+    importlib.reload(jarvis_module)
+
+    return jarvis_module.Jarvis(), outputs
+
+
+def test_execute_query_cpu(jarvis):
+    j, outputs = jarvis
+    j.execute_query("cpu")
+    assert "cpu" in outputs
+
+
+def test_execute_query_wikipedia(jarvis):
+    j, outputs = jarvis
+    j.execute_query("wikipedia python")
+    assert outputs[:3] == ["Searching Wikipedia....", "According to Wikipedia", "summary: python"]
+
+
+def test_execute_query_are_you_there(jarvis):
+    j, outputs = jarvis
+    j.execute_query("jarvis are you there")
+    assert outputs[-1] == "Yes Sir, at your service"


### PR DESCRIPTION
## Summary
- refactor Jarvis.execute_query() to use a dictionary of command handlers
- add new unit tests for Jarvis command dispatch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eaaeb5e78833380d460eca5969a3f